### PR TITLE
Small README.md improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ compinit # This is not necessary if it is called after this.
 ```
 
 You may have to force rebuild zcompdump
+
 ```console
-$ rm -f ~/.zcompdump && compinit
+$ rm -f "${ZDOTDIR-~}/.zcompdump" && compinit
 ```
 
 It is recommended that `compinit` be called only once because of the startup time.  


### PR DESCRIPTION
.zcompdump may exist in ZDOTDIR instead of ~ if zsh configuration paths use ZDOTDIR, for example to move zsh configs to "$HOME/.config/zsh".