### PR TITLE
fix: exclude git commands to prevent weird errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -131,6 +131,19 @@ func main() {
 					return
 				}
 
+				// NOTE: exclude git commands to prevent weird errors
+				// _git:8182: bad math expression: operand expected at `/home/user/...'
+				// _git:8182: bad math expression: operand expected at `/home/user/...'
+				// _git:8182: math recursion limit exceeded: name-rev
+				// _git:8182: bad math expression: operator expected at `browse'
+				if cmdName == "git" || strings.HasPrefix(cmdName, "git-") {
+					if isVerbose {
+						fmt.Printf("skipped git command: %s\n", fileName)
+					}
+					skippedNum++
+					return
+				}
+
 				srcFilePath := filepath.Join(srcDir, fileName)
 				srcFile, err := os.Open(filepath.Join(srcFilePath))
 				if err != nil {


### PR DESCRIPTION
I have confirmed that the following error occurs when the following files are placed

```
$ git
_git:8182: bad math expression: operand expected at `/home/user/...'
_git:8182: bad math expression: operand expected at `/home/user/...'
_git:8182: math recursion limit exceeded: name-rev
_git:8182: bad math expression: operator expected at `browse'
```

```
/home/user/.local/share/zsh/generated_man_completions/_git-web--browse
/home/user/.local/share/zsh/generated_man_completions/_git-name-rev
/home/user/.local/share/zsh/generated_man_completions/_git-merge-file
/home/user/.local/share/zsh/generated_man_completions/_git-cat-file
```

However, the specific cause has not been identified. I will exclude them because git completions are usually provided.